### PR TITLE
chore: remove Travis CI configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,0 @@
-language: php
-php:
-  - '7.2'


### PR DESCRIPTION
## Summary
- Removed Travis CI configuration file (`.travis.yml`)

## Test plan
- [ ] Verify no Travis CI references remain

🤖 Generated with [Claude Code](https://claude.com/claude-code)