### PR TITLE
docs(contributing): add build and run steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,12 +7,55 @@ development practices, refer to the **[Development Guide](https://github.com/rio
 
 ## Prerequisites
 
-- A text editor or IDE
+- [PHP 7.2+](https://www.php.net/downloads) installed and available in your `PATH`
+- A text editor or IDE (e.g. PhpStorm, VS Code)
+- Git
+
+## Running the Application
+
+### 1. Clone and Enter the Project
+
+```bash
+git clone https://github.com/rios0rios0/usocial-network.git
+cd usocial-network
+```
+
+### 2. Start the Development Server
+
+The project has no external dependencies to install. Use PHP's built-in web server to run the
+application locally:
+
+```bash
+php -S localhost:8000
+```
+
+### 3. Access the Application
+
+Open your browser and navigate to:
+
+```
+http://localhost:8000
+```
+
+You will be redirected to the sign-up/login page. From there you can register an account and explore
+the social network features (home feed, user profiles, user listing).
+
+### 4. Run the Linter (CI)
+
+The project uses a shared CI pipeline for linting. To run the same checks locally, use:
+
+```bash
+php -l index.php
+find app core -name "*.php" -exec php -l {} \;
+```
+
+This performs a syntax check on all PHP files, which is the baseline validation also executed in CI.
 
 ## Development Workflow
 
 1. Fork and clone the repository
 2. Create a branch: `git checkout -b feat/my-change`
 3. Make your changes
-4. Commit following the [commit conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
-5. Open a pull request against `main`
+4. Verify the application runs correctly (`php -S localhost:8000`)
+5. Commit following the [commit conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow)
+6. Open a pull request against `main`


### PR DESCRIPTION
## Summary

- Added detailed "Running the Application" section to CONTRIBUTING.md with 4 numbered steps: clone, start dev server, access in browser, and run linter
- Updated prerequisites to list PHP 7.2+ and Git as requirements
- Added a verification step in the development workflow to run the app before committing

## Context

The existing CONTRIBUTING.md had no instructions on how to actually build or run the project. After analyzing the source code (`index.php`, `core/routes/RoutesManagement.php`, `core/views/ViewsManagement.php`, etc.), the application is a pure PHP 7.2 project with no external dependencies that runs on PHP's built-in web server.

## Test plan

- [ ] Verify the steps work by cloning and running `php -S localhost:8000`
- [ ] Confirm `http://localhost:8000` redirects to the sign-up page
- [ ] Confirm `php -l` linting runs cleanly on all PHP files

🤖 Generated with [Claude Code](https://claude.com/claude-code)