### PR TITLE
fix(ci): updated workflow reference from php.yaml to composer.yaml

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   default:
-    uses: 'rios0rios0/pipelines/.github/workflows/php.yaml@main'
+    uses: 'rios0rios0/pipelines/.github/workflows/composer.yaml@main'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Fixed
+
+- fixed CI workflow reference after pipelines `v4.0.0` renamed `php.yaml` to `composer.yaml`
+
 ## [0.1.0] - 2026-03-12
 
 ### Added


### PR DESCRIPTION
## Summary

- Updated CI workflow reference from `php.yaml` to `composer.yaml` to match the pipelines repo `v4.0.0` toolchain naming convention rename
- The pipelines repo renamed all workflow files from language names to package manager names (e.g., `php.yaml` → `composer.yaml`, `java.yaml` → `gradle.yaml`) as a breaking change in `v4.0.0`

## Test plan

- [ ] Verify the GitHub Actions workflow triggers correctly on a PR and resolves `composer.yaml` from the pipelines repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)