### PR TITLE
chore(ci): migrated default.yaml from `composer.yaml` to `composer-library.yaml`

### DIFF
--- a/.github/workflows/default.yaml
+++ b/.github/workflows/default.yaml
@@ -16,4 +16,4 @@ permissions:
 
 jobs:
   default:
-    uses: 'rios0rios0/pipelines/.github/workflows/composer.yaml@main'
+    uses: 'rios0rios0/pipelines/.github/workflows/composer-library.yaml@main'


### PR DESCRIPTION
## Summary

Switched the reusable workflow reference from `rios0rios0/pipelines/.github/workflows/composer.yaml@main` to `rios0rios0/pipelines/.github/workflows/composer-library.yaml@main`.

## Why

`composer.yaml` is the validation-only variant — it has no `delivery-release` stage, so every `chore/bump-X.Y.Z` merge into `main` was leaving the repo without a Git tag/GitHub Release. The new `composer-library.yaml` calls the same validation under the hood and adds the `delivery-release` job, so future bumps will tag automatically.

Part of the broader migration tracked in https://github.com/rios0rios0/pipelines/pull/387.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
