### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -102,7 +102,7 @@ All dependencies are bundled in the repository — there is no package manager t
 
 ## CI/CD Pipeline
 
-The pipeline is defined in `.github/workflows/default.yaml` and delegates to the shared reusable workflow at `rios0rios0/pipelines/.github/workflows/composer.yaml@main`.
+The pipeline is defined in `.github/workflows/default.yaml` and delegates to the shared reusable workflow at `rios0rios0/pipelines/.github/workflows/composer-library.yaml@main`.
 
 Triggers:
 - Push to `main`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Added
+
+- added `CLAUDE.md` with build, architecture, convention, and CI guidance for Claude Code sessions
+
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to fix stale CI workflow reference (`composer.yaml` → `composer-library.yaml`)
+
 ## [0.1.2] - 2026-04-28
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Run
+
+No build step, no package manager (no Composer, no npm). All dependencies are bundled.
+
+```bash
+# Dev server
+php -S localhost:8000
+
+# Lint (same as CI)
+php -l index.php
+find app core -name "*.php" -exec php -l {} \;
+```
+
+## Database
+
+MySQL via PDO. Apply migrations in order:
+
+```bash
+mysql -u root -p usocial < db/2019051801_usocial.sql
+mysql -u root -p usocial < db/2019051802_usocial.sql
+```
+
+Credentials via env vars (`DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`) with defaults in `core/db/DatabaseConnection.php`.
+
+## Architecture
+
+MVC with service layer. Entry point: `index.php` → `RoutesManagement`.
+
+- **Controllers** (`app/controllers/`): thin request handlers, organized by feature subdirectory.
+- **Services** (`app/services/`): `UserService`, `PostService` — all business logic and DB interaction.
+- **Views** (`app/views/`): PHP templates rendered by `ViewsManagement`.
+- **Core** (`core/`): framework singletons — `DatabaseConnection`, `SessionManagement`, `RoutesManagement`, `ViewsManagement`.
+
+## Conventions
+
+- PHP 7.2+ features: object type hints, return type declarations, abstract method overrides.
+- All DB queries use PDO prepared statements — never interpolate user input into SQL.
+- Frontend assets in `resources/`; vendor libraries committed in `resources/plugins/`.
+- Commit messages follow [these conventions](https://github.com/rios0rios0/guide/wiki/Life-Cycle/Git-Flow) (e.g. `feat:`, `fix:`, `chore:`).
+- `CHANGELOG.md` follows [Keep a Changelog](https://keepachangelog.com/).
+
+## CI
+
+`.github/workflows/default.yaml` delegates to `rios0rios0/pipelines/.github/workflows/composer-library.yaml@main`. Runs PHP linting; tagged commits produce a GitHub Release.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.