### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ USocial Network is a social networking application built with PHP 7.2+. It demon
 usocial-network/
 ├── .github/
 │   └── workflows/
-│       └── default.yaml        # CI/CD pipeline (delegates to shared composer.yaml workflow)
+│       └── default.yaml        # CI/CD pipeline (delegates to shared composer-library.yaml workflow)
 ├── app/                        # Application layer (MVC)
 │   ├── controllers/            # Request handlers in subdirectories: home/, login/, post/, user/
 │   ├── services/               # Business logic: UserService, PostService

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `.github/copilot-instructions.md` to fix remaining stale CI workflow reference in directory tree (`composer.yaml` → `composer-library.yaml`)
+
 ## [0.2.0] - 2026-05-19
 
 ### Added


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.