### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -17,7 +17,7 @@ usocial-network/
 │   └── views/                  # PHP templates: login, home, user views, layouts, fragments
 ├── core/                       # Core framework components
 │   ├── db/                     # DatabaseConnection singleton (PDO + MySQL)
-│   ├── routes/                 # RoutesManagement: URL dispatch and base URL helpers
+│   ├── routes/                 # RoutesManagement: redirect + base-URL helpers (routing is filesystem-based)
 │   ├── session/                # SessionManagement singleton
 │   └── views/                  # ViewsManagement: template rendering engine
 ├── db/                         # SQL migration scripts (run in order)
@@ -93,7 +93,7 @@ Database credentials are configured via environment variables with fallback defa
 - **MVC**: Controllers in `app/controllers/` handle HTTP requests; services in `app/services/` contain business logic; templates in `app/views/` render HTML.
 - **Service Layer**: `UserService` and `PostService` encapsulate database interactions and domain logic, keeping controllers thin.
 - **Singleton**: `DatabaseConnection::getInstance()` and `SessionManagement::getInstance()` ensure a single shared instance per request.
-- **Central Router**: `RoutesManagement` in `core/routes/` dispatches URLs to the correct controller.
+- **Filesystem routing**: there is no central dispatcher or route table. A URL maps directly to a controller file path (e.g. `app/controllers/user/list.php`); `RoutesManagement` only provides `redirect()` and `base_url()` helpers. Controllers are procedural scripts, not classes.
 - **Template Rendering**: `ViewsManagement` in `core/views/` loads PHP view files and passes data to them.
 - **PDO Prepared Statements**: Database queries use PDO with prepared statements to parameterise user input.
 
@@ -145,10 +145,10 @@ The pipeline runs the `composer.json` scripts (`composer lint` for PHP syntax ch
 
 ### Add a new page/route
 
-1. Create a controller in `app/controllers/` extending the base controller pattern.
-2. Register the route in `core/routes/RoutesManagement.php`.
-3. Create the corresponding view template in `app/views/`.
-4. Add any business logic to a service in `app/services/`.
+1. Create a procedural controller script in the matching `app/controllers/` subdirectory (no base class) — it is reached directly by its file path (e.g. `app/controllers/user/list.php`); no route registration is needed.
+2. Link to it from a view with `<?= RoutesManagement::base_url() ?>app/controllers/...`.
+3. Create the corresponding view template in `app/views/` and render it via `ViewsManagement`.
+4. Put business logic and DB access in a service in `app/services/`.
 
 ### Add a database migration
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- corrected the routing model in `CLAUDE.md` and `.github/copilot-instructions.md`: routing is filesystem-based (a URL maps directly to a controller file path), controllers are procedural scripts with no base class, and `RoutesManagement` only provides `redirect()`/`base_url()` rather than dispatching routes; also fixed `CLAUDE.md` to stop labeling all four `core/` classes as singletons (only `DatabaseConnection` and `SessionManagement` use `getInstance()`)
+
 ## [0.2.2] - 2026-06-03
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,12 +33,12 @@ Credentials via env vars (`DB_HOST`, `DB_USER`, `DB_PASSWORD`, `DB_NAME`) with d
 
 ## Architecture
 
-MVC with service layer. Entry point: `index.php` → `RoutesManagement`.
+MVC with service layer. Entry point: `index.php` → `RoutesManagement`. Routing is filesystem-based: a URL maps directly to a controller file path (e.g. `app/controllers/user/list.php`, linked via `RoutesManagement::base_url()`) — there is no central route table.
 
-- **Controllers** (`app/controllers/`): thin request handlers, organized by feature subdirectory.
-- **Services** (`app/services/`): `UserService`, `PostService` — all business logic and DB interaction.
+- **Controllers** (`app/controllers/`): thin, procedural request-handler scripts (no base class), organized by feature subdirectory.
+- **Services** (`app/services/`): `UserService`, `PostService` — most business logic and DB interaction.
 - **Views** (`app/views/`): PHP templates rendered by `ViewsManagement`.
-- **Core** (`core/`): framework singletons — `DatabaseConnection`, `SessionManagement`, `RoutesManagement`, `ViewsManagement`.
+- **Core** (`core/`): framework classes — `DatabaseConnection` and `SessionManagement` are singletons (`getInstance()`); `RoutesManagement` is static-only (`redirect()`, `base_url()`); `ViewsManagement` is instantiated per render.
 
 ## Conventions
 


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.