### PR TITLE
chore(refresh): refreshed configuration and documentation

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -30,6 +30,7 @@ usocial-network/
 │   └── styles/
 ├── index.php                   # Entry point — bootstraps RoutesManagement
 ├── composer.json               # PHP constraint + lint/test scripts (no runtime deps)
+├── composer.lock               # committed (empty package set) to enable the CI composer-audit step
 ├── .env.example                # Sample DB env vars
 ├── README.md
 ├── CONTRIBUTING.md
@@ -120,7 +121,7 @@ Triggers:
 - Pull requests targeting `main`
 - Manual `workflow_dispatch`
 
-The pipeline runs the `composer.json` scripts (`composer lint` for PHP syntax checking). Tagged commits produce a GitHub Release.
+Beyond `composer lint` (PHP syntax checking) the pipeline runs security scanning: an SCA `composer-audit` step (`composer.lock` is committed with an empty package set solely to enable it) and semgrep SAST (`.semgrepignore` excludes `resources/plugins/`). Tagged commits produce a GitHub Release.
 
 ## Development Workflow
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ Exceptions are acceptable depending on the circumstances (critical bug fixes tha
 
 ## [Unreleased]
 
+### Changed
+
+- refreshed `CLAUDE.md` and `.github/copilot-instructions.md` to document that the CI pipeline runs security scanning beyond `composer lint` — an SCA `composer-audit` step (which is why the empty `composer.lock` is committed) and semgrep SAST (`.semgrepignore`)
+
 ## [0.2.3] - 2026-06-09
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,4 +50,4 @@ MVC with service layer. Entry point: `index.php` → `RoutesManagement`. Routing
 
 ## CI
 
-`.github/workflows/default.yaml` delegates to `rios0rios0/pipelines/.github/workflows/composer-library.yaml@main`, which runs the `composer.json` scripts (`composer lint` for PHP syntax checking). Tagged commits produce a GitHub Release.
+`.github/workflows/default.yaml` delegates to `rios0rios0/pipelines/.github/workflows/composer-library.yaml@main`. Beyond `composer lint` (PHP syntax checking) it runs security scanning: an SCA `composer-audit` step — `composer.lock` is committed (with an empty package set) solely to enable that audit — and semgrep SAST (`.semgrepignore` excludes `resources/plugins/`). Tagged commits produce a GitHub Release.


### PR DESCRIPTION
Automated weekly refresh by `config-and-docs-refresh.yaml` in `rios0rios0/config-automation`.

Claude Code reviewed the in-scope configuration and documentation files (currently `CLAUDE.md` and `.github/copilot-instructions.md`) against the current code, updated whichever drifted, and recorded the change in `CHANGELOG.md` (when the repo has one).

Review the diff carefully --- this PR was generated by Claude Code and may contain inaccuracies.